### PR TITLE
Move maxNumberOfDays early-out after min/max are calculated for last day

### DIFF
--- a/MMM-weatherforecast.js
+++ b/MMM-weatherforecast.js
@@ -508,6 +508,10 @@ Module.register("MMM-weatherforecast",{
 			}
 
 			if (day !== lastDay) {
+				// Stop processing when maxNumberOfDays is reached
+				if (this.forecast.length === this.config.maxNumberOfDays) {
+					break;
+				}
 				var forecastData = {
 					day: day,
 					icon: this.config.iconTable[forecast.weather[0].icon],
@@ -519,10 +523,6 @@ Module.register("MMM-weatherforecast",{
 				this.forecast.push(forecastData);
 				lastDay = day;
 
-				// Stop processing when maxNumberOfDays is reached
-				if (this.forecast.length === this.config.maxNumberOfDays) {
-					break;
-				}
 			} else {
 				//Log.log("Compare max: ", forecast.temp.max, parseFloat(forecastData.maxTemp));
 				forecastData.maxTemp = forecast.temp.max > parseFloat(forecastData.maxTemp) ? this.roundValue(forecast.temp.max) : forecastData.maxTemp;


### PR DESCRIPTION
Rather than checking if maxNumberOfDays has been reached after the first entry on the last day, the check is moved to the start of the loop, ensuring that it will only be checked after the min/max calculations have been completed for the final day.  This fixes issue #10 